### PR TITLE
Use fs.readSync's options to get base64 string

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = postcss.plugin('postcss-data-uri', function (opts) {
             if (rePattern.test(decl.value)) {
                 path = decl.value.match(rePattern)[1];
                 if (fs.existsSync(path)) {
-                    decl.value = decl.value.replace(rePattern, 'url(data:' + mime.lookup(path) + ';base64,' + new Buffer(fs.readFileSync(path)).toString('base64') + ')');
+                    decl.value = decl.value.replace(rePattern, 'url(data:' + mime.lookup(path) + ';base64,' + fs.readFileSync(path, 'base64') + ')');
                 } else {
                     console.log('Image ',path,' not found.')
                 }


### PR DESCRIPTION
A tiny simplification. I've done this in my project and it works fine. Submitting the PR to see if tests pass. 